### PR TITLE
php7 compatibility

### DIFF
--- a/includes/classes/sitemapxml.php
+++ b/includes/classes/sitemapxml.php
@@ -72,7 +72,7 @@ class zen_SiteMapXML {
   var $statisticModuleQueries = 0;
   var $statisticModuleQueriesTime = 0;
 
-  function zen_SiteMapXML($inline=false, $ping=false, $rebuild=false, $genxml=true) {
+  function __construct($inline=false, $ping=false, $rebuild=false, $genxml=true) {
     global $db;
     $this->statisticTotalTime = microtime(true);
     $this->statisticTotalQueries = $db->count_queries;


### PR DESCRIPTION
for the module not to break in php7 functions with the same name as the class name need to be renamed to __construct

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/andrewberezin/zen-cart-sitemap-xml/1)

<!-- Reviewable:end -->
